### PR TITLE
0.0.2: [fix] -  Uint32 type for Chain Id

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -101,7 +101,7 @@ var encode = (key, value) => {
   tagBuf.writeUInt8(parameterToTag[key]);
   switch (key) {
     case "chainId": {
-      const encodedLengthAndValue = int16Encoder(parseInt(value, 16));
+      const encodedLengthAndValue = int32Encoder(parseInt(value, 16));
       return Buffer.concat([tagBuf, encodedLengthAndValue]);
     }
     case "code": {
@@ -255,7 +255,7 @@ var decode = (tag, value) => {
   const key = tagToParameter[tag];
   switch (key) {
     case "chainId": {
-      const decodedValue = int16Parser(value);
+      const decodedValue = int32Parser(value);
       return { key, value: `0x${decodedValue.toString(16)}` };
     }
     case "code": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tex-serializer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "module": "dist/index.js",
   "type": "module",
   "devDependencies": {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -31,7 +31,7 @@ const decode = (
 
   switch (key) {
     case 'chainId': {
-      const decodedValue = int16Parser(value)
+      const decodedValue = int32Parser(value)
       return { key, value: `0x${decodedValue.toString(16)}` }
     }
     case 'code': {
@@ -236,7 +236,7 @@ const decode = (
   }
 }
 
-export const deserialize: Deserializer = (data) => {
+export const deserialize: Deserializer = data => {
   const buf = Buffer.from(data)
   const message: Message = {} as Message
   let cursor = 0

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -69,7 +69,7 @@ const encode = (key: string, value: unknown): Buffer | null => {
 
   switch (key) {
     case 'chainId': {
-      const encodedLengthAndValue = int16Encoder(parseInt(value as string, 16))
+      const encodedLengthAndValue = int32Encoder(parseInt(value as string, 16))
       return Buffer.concat([tagBuf, encodedLengthAndValue])
     }
     case 'code': {
@@ -217,7 +217,7 @@ const encode = (key: string, value: unknown): Buffer | null => {
   }
 }
 
-export const serialize: Serializer = (message) => {
+export const serialize: Serializer = message => {
   let encoded = Buffer.allocUnsafe(0)
 
   Object.entries(message).forEach(([key, value]) => {


### PR DESCRIPTION
Some chain id's do not fit in a 16 bit integer. Sepolia (`11155111`) being one of them. This PR changes the `chainId` to a Uint32 type.