### PR TITLE
0.0.3: [enhancement] - Add Error Handling for Transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tex-serializer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "module": "dist/index.js",
   "type": "module",
   "devDependencies": {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -115,7 +115,17 @@ const decode = (
 
           const val = txVal.subarray(txCursor, txCursor + len)
           txCursor += len
-          const decoded = decode(tag, val)
+
+          let decoded: { key: string; value: unknown } | null = null
+
+          try {
+            decoded = decode(tag, val)
+          } catch (error) {
+            const { message } = error as Error
+            console.error(
+              `Error decoding tag: ${tag}, value: ${val} - ${message}`
+            )
+          }
 
           if (decoded) {
             const { key, value } = decoded

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -137,22 +137,27 @@ const encode = (key: string, value: unknown): Buffer | null => {
         | MempoolTransaction
         | CompletedTransaction
       )[]) {
-        let encodedTransaction = Buffer.allocUnsafe(0)
+        try {
+          let encodedTransaction = Buffer.allocUnsafe(0)
 
-        Object.entries(transaction).forEach(([key, value]) => {
-          const encoded = encode(key, value)
-          if (encoded) {
-            encodedTransaction = Buffer.concat([encodedTransaction, encoded])
-          }
-        })
+          Object.entries(transaction).forEach(([key, value]) => {
+            const encoded = encode(key, value)
+            if (encoded) {
+              encodedTransaction = Buffer.concat([encodedTransaction, encoded])
+            }
+          })
 
-        const encodedTransactionsLength = Buffer.allocUnsafe(2)
-        encodedTransactionsLength.writeUInt16BE(encodedTransaction.byteLength)
+          const encodedTransactionsLength = Buffer.allocUnsafe(2)
+          encodedTransactionsLength.writeUInt16BE(encodedTransaction.byteLength)
 
-        allEncodedTransactions = Buffer.concat([
-          allEncodedTransactions,
-          Buffer.concat([encodedTransactionsLength, encodedTransaction]),
-        ])
+          allEncodedTransactions = Buffer.concat([
+            allEncodedTransactions,
+            Buffer.concat([encodedTransactionsLength, encodedTransaction]),
+          ])
+        } catch (error) {
+          const { message } = error as Error
+          console.error(`Error serializing transaction: ${message}`)
+        }
       }
 
       const txsLength = Buffer.allocUnsafe(4)


### PR DESCRIPTION
This PR adds error handling specifically for the `transactions` field so that if one transaction fails to be serialized or de-serialized, then we log an error, but continue to process the rest of the transactions in the list.