### PR TITLE
0.2.4 : [FIX] - Add missing `blobCount` prop to `BlockMessageV1` type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -43,6 +43,7 @@ export type BlockMessageV1 = MessageBase & {
 	height: number;
 	timestamp: string;
 	txnCount: number;
+	blobCount: number;
 	/** hex */
 	baseFeePerGas: string;
 	gasUsed: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tex-serializer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "module": "dist/index.js",
   "type": "module",
   "devDependencies": {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -71,6 +71,7 @@ export type BlockMessageV1 = MessageBase & {
   height: number
   timestamp: string
   txnCount: number
+  blobCount: number
   /** hex */
   baseFeePerGas: string
   gasUsed: number


### PR DESCRIPTION
Functionality already existed - `blobCount` was just missing rom the `BlockMessageV1` type