### PR TITLE
0.2.7 : [UPDATE] - Add mempool txn counts for full  and marketable mempool size

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -36,8 +36,8 @@ export type MempoolMessageV1 = MessageBase & {
 	mempoolData?: MempoolData;
 };
 export type MempoolData = {
-	marketableCount: number;
-	totalCount: number;
+	marketableCount?: number;
+	totalCount?: number;
 };
 export type BlockMessageV1 = MessageBase & {
 	/** tx hashes included in block */

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -33,11 +33,6 @@ export type MessageBase = {
 };
 export type MempoolMessageV1 = MessageBase & {
 	transactions: MempoolTransactionV1[];
-	mempoolData?: MempoolData;
-};
-export type MempoolData = {
-	marketableCount?: number;
-	totalCount?: number;
 };
 export type BlockMessageV1 = MessageBase & {
 	/** tx hashes included in block */
@@ -63,10 +58,15 @@ export type ErrorMessage = MessageBase & {
 export type AckMessage = {
 	id: string;
 };
+export type TotalMempoolCounts = {
+	marketableCount?: number;
+	totalCount?: number;
+};
 export type Stats = {
 	marketableCount: number;
 	underpricedCount: number;
 	blockedCount: number;
+	totalMempoolCounts: TotalMempoolCounts;
 };
 export type StatsMessage = MessageBase & {
 	stats: Stats;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -63,9 +63,22 @@ export type TotalMempoolCounts = {
 	totalCount: number;
 };
 export type Stats = {
+	/**
+	 * Marketable txn count that has arrived since the last block
+	 * */
 	marketableCount: number;
+	/**
+	 * Underpriced txn count that has arrived since the last block
+	 * */
 	underpricedCount: number;
+	/**
+	 * Blocked txn count that has arrived since the last block
+	 * */
 	blockedCount: number;
+	/**
+	 * Mempool counts for both full and marketable mempoools regardless of when the txns arrived.
+	 * Top level count properties are counts of txns that have arrived since last block.
+	 * */
 	totalMempoolCounts: TotalMempoolCounts;
 };
 export type StatsMessage = MessageBase & {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -59,14 +59,14 @@ export type AckMessage = {
 	id: string;
 };
 export type TotalMempoolCounts = {
-	marketableCount?: number;
-	totalCount?: number;
+	marketableCount: number;
+	totalCount: number;
 };
 export type Stats = {
 	marketableCount: number;
 	underpricedCount: number;
 	blockedCount: number;
-	totalMempoolCounts: TotalMempoolCounts;
+	totalMempoolCounts?: TotalMempoolCounts;
 };
 export type StatsMessage = MessageBase & {
 	stats: Stats;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -66,7 +66,7 @@ export type Stats = {
 	marketableCount: number;
 	underpricedCount: number;
 	blockedCount: number;
-	totalMempoolCounts?: TotalMempoolCounts;
+	totalMempoolCounts: TotalMempoolCounts;
 };
 export type StatsMessage = MessageBase & {
 	stats: Stats;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -33,6 +33,11 @@ export type MessageBase = {
 };
 export type MempoolMessageV1 = MessageBase & {
 	transactions: MempoolTransactionV1[];
+	mempoolData?: MempoolData;
+};
+export type MempoolData = {
+	marketableCount: number;
+	totalCount: number;
 };
 export type BlockMessageV1 = MessageBase & {
 	/** tx hashes included in block */

--- a/dist/index.js
+++ b/dist/index.js
@@ -57,7 +57,7 @@ var parameterToTag = {
   marketableCount: 54,
   underpricedCount: 55,
   blockedCount: 56,
-  mempoolData: 57,
+  totalMempoolCounts: 57,
   totalCount: 58
 };
 var tagToParameter = Object.fromEntries(Object.entries(parameterToTag).map(([parameter, tag]) => [tag, parameter]));
@@ -328,7 +328,7 @@ var encodeV1 = (key, value) => {
       len.writeUInt16BE(encodedHomepagePending.byteLength);
       return Buffer.concat([tagBuf, len, encodedHomepagePending]);
     }
-    case "mempoolData": {
+    case "totalMempoolCounts": {
       let encodedHomepagePending = Buffer.allocUnsafe(0);
       Object.entries(value).forEach(([key2, value2]) => {
         const encoded = encodeV1(key2, value2);
@@ -629,8 +629,8 @@ var decodeV1 = (tag, value) => {
       }
       return { key, value: decodedMarketableSegmentStats };
     }
-    case "mempoolData": {
-      const decodedMempoolData = {};
+    case "totalMempoolCounts": {
+      const decodedTotalMempoolCounts = {};
       let cursor = 0;
       while (cursor < value.byteLength) {
         const tag2 = value.readUInt8(cursor);
@@ -648,12 +648,12 @@ var decodeV1 = (tag, value) => {
         const decoded = decodeV1(tag2, val);
         if (decoded) {
           const { key: key2, value: value2 } = decoded;
-          decodedMempoolData[key2] = value2;
+          decodedTotalMempoolCounts[key2] = value2;
         } else {
           console.warn(`Unknown tag: ${tag2}  ${val}`);
         }
       }
-      return { key, value: decodedMempoolData };
+      return { key, value: decodedTotalMempoolCounts };
     }
     default:
       return null;

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,9 @@ var parameterToTag = {
   blobDiscount: 53,
   marketableCount: 54,
   underpricedCount: 55,
-  blockedCount: 56
+  blockedCount: 56,
+  mempoolData: 57,
+  totalCount: 58
 };
 var tagToParameter = Object.fromEntries(Object.entries(parameterToTag).map(([parameter, tag]) => [tag, parameter]));
 var getTagLengthBytes = (tag) => {
@@ -71,6 +73,7 @@ var getTagLengthBytes = (tag) => {
     case 39:
     case 44:
     case 45:
+    case 57:
       return 2;
     default:
       return 1;
@@ -173,6 +176,7 @@ var encodeV1 = (key, value) => {
     case "privateBlobCount":
     case "blobCount":
     case "batchesCount":
+    case "totalCount":
     case "txnCount": {
       const encodedLengthAndValue = int16Encoder(value);
       return Buffer.concat([tagBuf, encodedLengthAndValue]);
@@ -324,6 +328,21 @@ var encodeV1 = (key, value) => {
       len.writeUInt16BE(encodedHomepagePending.byteLength);
       return Buffer.concat([tagBuf, len, encodedHomepagePending]);
     }
+    case "mempoolData": {
+      let encodedHomepagePending = Buffer.allocUnsafe(0);
+      Object.entries(value).forEach(([key2, value2]) => {
+        const encoded = encodeV1(key2, value2);
+        if (encoded) {
+          encodedHomepagePending = Buffer.concat([
+            encodedHomepagePending,
+            encoded
+          ]);
+        }
+      });
+      const len = Buffer.allocUnsafe(2);
+      len.writeUInt16BE(encodedHomepagePending.byteLength);
+      return Buffer.concat([tagBuf, len, encodedHomepagePending]);
+    }
     default:
       return null;
   }
@@ -380,6 +399,7 @@ var decodeV1 = (tag, value) => {
     case "privateBlobCount":
     case "blobCount":
     case "batchesCount":
+    case "totalCount":
     case "txnCount": {
       const decodedValue = int16Parser(value);
       return { key, value: decodedValue };
@@ -608,6 +628,32 @@ var decodeV1 = (tag, value) => {
         }
       }
       return { key, value: decodedMarketableSegmentStats };
+    }
+    case "mempoolData": {
+      const decodedMempoolData = {};
+      let cursor = 0;
+      while (cursor < value.byteLength) {
+        const tag2 = value.readUInt8(cursor);
+        cursor++;
+        let len;
+        if (getTagLengthBytes(tag2) === 2) {
+          len = value.readUInt16BE(cursor);
+          cursor += 2;
+        } else {
+          len = value.readUInt8(cursor);
+          cursor++;
+        }
+        const val = value.subarray(cursor, len + cursor);
+        cursor += len;
+        const decoded = decodeV1(tag2, val);
+        if (decoded) {
+          const { key: key2, value: value2 } = decoded;
+          decodedMempoolData[key2] = value2;
+        } else {
+          console.warn(`Unknown tag: ${tag2}  ${val}`);
+        }
+      }
+      return { key, value: decodedMempoolData };
     }
     default:
       return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tex-serializer",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "module": "dist/index.js",
   "type": "module",
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,7 +56,9 @@ export const parameterToTag: Record<string, number> = {
   blobDiscount: 53,
   marketableCount: 54,
   underpricedCount: 55,
-  blockedCount: 56
+  blockedCount: 56,
+  mempoolData: 57,
+  totalCount: 58
 }
 
 export const tagToParameter: Record<number, string> = Object.fromEntries(
@@ -75,6 +77,7 @@ export const getTagLengthBytes = (tag: number): number => {
     case 39:
     case 44:
     case 45:
+    case 57:
       return 2
     default:
       return 1

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,7 +57,7 @@ export const parameterToTag: Record<string, number> = {
   marketableCount: 54,
   underpricedCount: 55,
   blockedCount: 56,
-  mempoolData: 57,
+  totalMempoolCounts: 57,
   totalCount: 58
 }
 

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -11,7 +11,7 @@ import {
   TransactionSegmentStats,
   L2SegmentStats,
   MarketableSegmentStats,
-  MempoolData
+  TotalMempoolCounts
 } from './types-v1'
 
 export const hexParser = (buf: Buffer) => {
@@ -367,9 +367,9 @@ const decodeV1 = (
 
       return { key, value: decodedMarketableSegmentStats }
     }
-    case 'mempoolData': {
-      const decodedMempoolData: MempoolData =
-        {} as MempoolData
+    case 'totalMempoolCounts': {
+      const decodedTotalMempoolCounts: TotalMempoolCounts =
+        {} as TotalMempoolCounts
       let cursor = 0
 
       while (cursor < value.byteLength) {
@@ -393,14 +393,14 @@ const decodeV1 = (
         if (decoded) {
           const { key, value } = decoded
           // @ts-ignore
-          decodedMempoolData[key as keyof MempoolData] =
-            value as ValueOf<MempoolData>
+          decodedTotalMempoolCounts[key as keyof TotalMempoolCounts] =
+            value as ValueOf<TotalMempoolCounts>
         } else {
           console.warn(`Unknown tag: ${tag}  ${val}`)
         }
       }
 
-      return { key, value: decodedMempoolData }
+      return { key, value: decodedTotalMempoolCounts }
     }
     default:
       return null

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -10,7 +10,8 @@ import {
   DeserializedResponse,
   TransactionSegmentStats,
   L2SegmentStats,
-  MarketableSegmentStats
+  MarketableSegmentStats,
+  MempoolData
 } from './types-v1'
 
 export const hexParser = (buf: Buffer) => {
@@ -70,6 +71,7 @@ const decodeV1 = (
     case 'privateBlobCount':
     case 'blobCount':
     case 'batchesCount':
+    case 'totalCount':
     case 'txnCount': {
       const decodedValue = int16Parser(value)
       return { key, value: decodedValue }
@@ -364,6 +366,41 @@ const decodeV1 = (
       }
 
       return { key, value: decodedMarketableSegmentStats }
+    }
+    case 'mempoolData': {
+      const decodedMempoolData: MempoolData =
+        {} as MempoolData
+      let cursor = 0
+
+      while (cursor < value.byteLength) {
+        const tag = value.readUInt8(cursor)
+        cursor++
+
+        let len: number
+
+        if (getTagLengthBytes(tag) === 2) {
+          len = value.readUInt16BE(cursor)
+          cursor += 2
+        } else {
+          len = value.readUInt8(cursor)
+          cursor++
+        }
+
+        const val = value.subarray(cursor, len + cursor)
+        cursor += len
+        const decoded = decodeV1(tag, val)
+
+        if (decoded) {
+          const { key, value } = decoded
+          // @ts-ignore
+          decodedMempoolData[key as keyof MempoolData] =
+            value as ValueOf<MempoolData>
+        } else {
+          console.warn(`Unknown tag: ${tag}  ${val}`)
+        }
+      }
+
+      return { key, value: decodedMempoolData }
     }
     default:
       return null

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -8,7 +8,8 @@ import {
   type MempoolTransactionV1,
   type CompletedTransaction,
   type Stats,
-  MarketableSegmentStats
+  MarketableSegmentStats,
+  MempoolData
 } from './types-v1.ts'
 
 const hexEncoder = (hex: string) => {
@@ -124,6 +125,7 @@ const encodeV1 = (key: string, value: unknown): Buffer | null => {
     case 'privateBlobCount':
     case 'blobCount':
     case 'batchesCount':
+    case 'totalCount':
     case 'txnCount': {
       const encodedLengthAndValue = int16Encoder(value as number)
       return Buffer.concat([tagBuf, encodedLengthAndValue])
@@ -299,6 +301,7 @@ const encodeV1 = (key: string, value: unknown): Buffer | null => {
 
       return Buffer.concat([tagBuf, len, encodedHomepagePending])
     }
+
     case 'marketable': {
       let encodedHomepagePending = Buffer.allocUnsafe(0)
 
@@ -314,6 +317,26 @@ const encodeV1 = (key: string, value: unknown): Buffer | null => {
           }
         }
       )
+
+      const len = Buffer.allocUnsafe(2)
+      len.writeUInt16BE(encodedHomepagePending.byteLength)
+
+      return Buffer.concat([tagBuf, len, encodedHomepagePending])
+    }
+
+    case 'mempoolData': {
+      let encodedHomepagePending = Buffer.allocUnsafe(0)
+
+      Object.entries(value as MempoolData).forEach(([key, value]) => {
+        const encoded = encodeV1(key, value)
+
+        if (encoded) {
+          encodedHomepagePending = Buffer.concat([
+            encodedHomepagePending,
+            encoded
+          ])
+        }
+      })
 
       const len = Buffer.allocUnsafe(2)
       len.writeUInt16BE(encodedHomepagePending.byteLength)

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -9,7 +9,7 @@ import {
   type CompletedTransaction,
   type Stats,
   MarketableSegmentStats,
-  MempoolData
+  TotalMempoolCounts
 } from './types-v1.ts'
 
 const hexEncoder = (hex: string) => {
@@ -324,10 +324,10 @@ const encodeV1 = (key: string, value: unknown): Buffer | null => {
       return Buffer.concat([tagBuf, len, encodedHomepagePending])
     }
 
-    case 'mempoolData': {
+    case 'totalMempoolCounts': {
       let encodedHomepagePending = Buffer.allocUnsafe(0)
 
-      Object.entries(value as MempoolData).forEach(([key, value]) => {
+      Object.entries(value as TotalMempoolCounts).forEach(([key, value]) => {
         const encoded = encodeV1(key, value)
 
         if (encoded) {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -62,6 +62,12 @@ type MessageBase = {
 
 export type MempoolMessageV1 = MessageBase & {
   transactions: MempoolTransactionV1[]
+  mempoolData?: MempoolData
+}
+
+export type MempoolData = {
+  marketableCount: number
+  totalCount: number
 }
 
 export type BlockMessageV1 = MessageBase & {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -98,7 +98,7 @@ export type Stats = {
   marketableCount: number
   underpricedCount: number
   blockedCount: number
-  totalMempoolCounts?: TotalMempoolCounts
+  totalMempoolCounts: TotalMempoolCounts
 }
 
 export type StatsMessage = MessageBase & {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -90,15 +90,15 @@ export type AckMessage = {
 }
 
 export type TotalMempoolCounts = {
-  marketableCount?: number
-  totalCount?: number
+  marketableCount: number
+  totalCount: number
 }
 
 export type Stats = {
   marketableCount: number
   underpricedCount: number
   blockedCount: number
-  totalMempoolCounts: TotalMempoolCounts
+  totalMempoolCounts?: TotalMempoolCounts
 }
 
 export type StatsMessage = MessageBase & {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -62,12 +62,6 @@ type MessageBase = {
 
 export type MempoolMessageV1 = MessageBase & {
   transactions: MempoolTransactionV1[]
-  mempoolData?: MempoolData
-}
-
-export type MempoolData = {
-  marketableCount?: number
-  totalCount?: number
 }
 
 export type BlockMessageV1 = MessageBase & {
@@ -95,10 +89,16 @@ export type AckMessage = {
   id: string
 }
 
+export type TotalMempoolCounts = {
+  marketableCount?: number
+  totalCount?: number
+}
+
 export type Stats = {
   marketableCount: number
   underpricedCount: number
   blockedCount: number
+  totalMempoolCounts: TotalMempoolCounts
 }
 
 export type StatsMessage = MessageBase & {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -66,8 +66,8 @@ export type MempoolMessageV1 = MessageBase & {
 }
 
 export type MempoolData = {
-  marketableCount: number
-  totalCount: number
+  marketableCount?: number
+  totalCount?: number
 }
 
 export type BlockMessageV1 = MessageBase & {

--- a/src/types-v1.ts
+++ b/src/types-v1.ts
@@ -95,9 +95,22 @@ export type TotalMempoolCounts = {
 }
 
 export type Stats = {
+  /**
+   * Marketable txn count that has arrived since the last block
+   * */
   marketableCount: number
+  /**
+   * Underpriced txn count that has arrived since the last block
+   * */
   underpricedCount: number
+  /**
+   * Blocked txn count that has arrived since the last block
+   * */
   blockedCount: number
+  /**
+   * Mempool counts for both full and marketable mempoools regardless of when the txns arrived.
+   * Top level count properties are counts of txns that have arrived since last block.
+   * */
   totalMempoolCounts: TotalMempoolCounts
 }
 

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -1,6 +1,10 @@
 export const mempoolMessage = {
   feed: 'mempool',
   chainId: '0x1',
+  mempoolData: {
+    totalCount: 3212,
+    marketableCount: 98
+  },
   transactions: [
     {
       hash: '0x57626ec0009c20dc367e1f36a326bac3f76a7f375f4147383986096dd49d6109',

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -1,10 +1,6 @@
 export const mempoolMessage = {
   feed: 'mempool',
   chainId: '0x1',
-  mempoolData: {
-    totalCount: 3212,
-    marketableCount: 98
-  },
   transactions: [
     {
       hash: '0x57626ec0009c20dc367e1f36a326bac3f76a7f375f4147383986096dd49d6109',
@@ -1051,7 +1047,11 @@ export const statsMessage = {
   stats: {
     blockedCount: 40,
     marketableCount: 20,
-    underpricedCount: 30
+    underpricedCount: 30,
+    totalMempoolCounts: {
+      totalCount: 3212,
+      marketableCount: 98
+    }
   }
 }
 


### PR DESCRIPTION
Add `TotalMempoolCounts` prop to the Stats message to pass full and marketable mempool size to the client with the stats message. This differs from the top level `marketableCount` as the top level is the count since the last block while `TotalMempoolCount` is the count of all txns in the mempools regardless of when they arrived.
```typescript
export type TotalMempoolCounts = {
  marketableCount: number
  totalCount: number
}

export type Stats = {
  marketableCount: number
  underpricedCount: number
  blockedCount: number
  totalMempoolCounts: TotalMempoolCounts
}
```